### PR TITLE
Fix GitHub capitalization in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean: ## Clean build artifacts
 	rm -rf node_modules
 
 .PHONY: faucet
-faucet: ## Drip 3 ZETA testnet tokens to the desired address every 24h. (Requires Github login).
+faucet: ## Drip 3 ZETA testnet tokens to the desired address every 24h. (Requires GitHub login).
 	@echo "Dripping 3 ZETA testnet tokens to $(ADDRESS)"
 	npx zetafaucet --drip --address $(ADDRESS)
 


### PR DESCRIPTION
## Summary
- correct the word "GitHub" in the faucet task description of the Makefile

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684803ca738c83268b3acdb3395cd962